### PR TITLE
bugfix: use the actual expiration on dealer timeout entries

### DIFF
--- a/lib/liblink/timeout.ex
+++ b/lib/liblink/timeout.ex
@@ -23,10 +23,21 @@ defmodule Liblink.Timeout do
   end
 
   @spec deadline_expired?(deadline_t) :: boolean
-  def deadline_expired?(:infinity), do: false
+  def deadline_expired?(deadline) when is_integer(deadline) or is_atom(deadline) do
+    deadline_expired?(deadline, current())
+  end
 
-  def deadline_expired?(deadline) when is_integer(deadline) do
-    :erlang.monotonic_time() > deadline
+  @spec deadline_expired?(deadline_t, deadline_t) :: boolean
+  def deadline_expired?(:infinity, _), do: false
+  def deadline_expired?(_, :infinity), do: false
+
+  def deadline_expired?(deadline, sysnow) when is_integer(deadline) and is_integer(sysnow) do
+    sysnow > deadline
+  end
+
+  @spec current() :: deadline_t
+  def current() do
+    :erlang.monotonic_time()
   end
 
   @spec timeout_mul(timeout, float | integer) :: timeout


### PR DESCRIPTION
we were using a discrete number as the timeout entry and on each
`timeout_step` this value was decremented. when it reached zero, the
system assumed that entry expired. this mechanism was flawed because
at the time the timeout entry is created the elapsed time until the
next `timeout_step` execute might actually be really small. thus the
entry times out almost immediately.

we could fix by using a greater initial value, demanding two or more
runs between considering an entry expired. instead we decided to use
the deadline itself and the Timeout module which give us a precise
mechanism.