### PR TITLE
improve logger

### DIFF
--- a/lib/liblink/cluster/announce/request_response.ex
+++ b/lib/liblink/cluster/announce/request_response.ex
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 defmodule Liblink.Cluster.Announce.RequestResponse do
+  use Liblink.Logger
+
   alias Liblink.Random
   alias Liblink.Socket
   alias Liblink.Socket.Device
@@ -27,8 +29,6 @@ defmodule Liblink.Cluster.Announce.RequestResponse do
   alias Liblink.Cluster.Protocol.Router
 
   import Liblink.Data.Macros
-
-  require Logger
 
   # XXX: can't make dialyzer accept these functions
   @dialyzer [{:nowarn_function, new: 2, new!: 2}]
@@ -116,20 +116,14 @@ defmodule Liblink.Cluster.Announce.RequestResponse do
     else
       case Agent.service_register(state.consul, service) do
         {:ok, %{status: 200}} ->
-          _ =
-            Logger.info(
-              "successfully registered service on consul",
-              metadata: [data: [service: service.name]]
-            )
+          Logger.info("successfully registered service on consul: service=#{service.name}")
 
           {:ok, service}
 
         error ->
-          _ =
-            Logger.warn(
-              "error registering service on consul",
-              metadata: [data: [service: service.name], error: error]
-            )
+          Logger.warn(
+            "error registering service on consul: service=#{service.name} error=#{inspect(error)}"
+          )
 
           :error
       end
@@ -145,11 +139,9 @@ defmodule Liblink.Cluster.Announce.RequestResponse do
         :ok
 
       error ->
-        _ =
-          Logger.warn(
-            "error invoking check_pass on consul",
-            metadata: [data: [service: service.name, error: error]]
-          )
+        Logger.warn(
+          "error invoking check_pass on consul. service=#{service.name} error=#{inspect(error)}"
+        )
 
         :error
     end

--- a/lib/liblink/cluster/discover/client_device.ex
+++ b/lib/liblink/cluster/discover/client_device.ex
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 defmodule Liblink.Cluster.Discover.ClientDevice do
+  use Liblink.Logger
   use Liblink.Cluster.Database.Hook
 
   alias Liblink.Cluster.Database.Query
   alias Liblink.Cluster.Protocol.Dealer
-
-  require Logger
 
   @impl true
   def after_hook(_pid, tid, event) do
@@ -61,11 +60,11 @@ defmodule Liblink.Cluster.Discover.ClientDevice do
       :ok
     catch
       :exit, {:noproc, {GenServer, :call, _}} ->
-        _ = Logger.warn("could not attach device to dealer: noproc")
+        Logger.warn("could not attach device to dealer: noproc")
         :error
 
       :exit, {:timeout, {GenServer, :call, _}} ->
-        _ = Logger.warn("could not attach device to dealer: timeout")
+        Logger.warn("could not attach device to dealer: timeout")
         :error
     end
   end

--- a/lib/liblink/cluster/discover/device.ex
+++ b/lib/liblink/cluster/discover/device.ex
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 defmodule Liblink.Cluster.Discover.Device do
+  use Liblink.Logger
   use Liblink.Cluster.Database.Hook
 
   alias Liblink.Socket
   alias Liblink.Cluster.Database.Mutation
-
-  require Logger
 
   @impl true
   def after_hook(pid, _tid, event) do
@@ -51,7 +50,7 @@ defmodule Liblink.Cluster.Discover.Device do
               )
 
             _error ->
-              _ = Logger.warn("error creating socket for endpoint: #{endpoint}")
+              Logger.warn("error creating socket for endpoint #{endpoint}")
           end
         end)
 

--- a/lib/liblink/cluster/discover/service.ex
+++ b/lib/liblink/cluster/discover/service.ex
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 defmodule Liblink.Cluster.Discover.Service do
+  use Liblink.Logger
+
   alias Liblink.Data.Cluster
   alias Liblink.Data.Cluster.RemoteService
   alias Liblink.Data.Cluster.Discover
@@ -21,8 +23,6 @@ defmodule Liblink.Cluster.Discover.Service do
   alias Liblink.Network.Consul
   alias Liblink.Cluster.Database
   alias Liblink.Cluster.Database.Mutation
-
-  require Logger
 
   @type t :: map
 
@@ -48,7 +48,7 @@ defmodule Liblink.Cluster.Discover.Service do
           handle_service(state, services)
 
         _reply ->
-          _ = Logger.warn("error reading services from consul")
+          Logger.warn("error reading services from consul")
       end
 
     state
@@ -70,7 +70,7 @@ defmodule Liblink.Cluster.Discover.Service do
             end
 
           error ->
-            _ = Logger.error("error reading services from consul: #{inspect(error)}")
+            _ = Logger.error("error reading services from consul: error=#{inspect(error)}")
             {:halt, :error}
         end
       end)
@@ -124,11 +124,7 @@ defmodule Liblink.Cluster.Discover.Service do
       )
     else
       _ ->
-        _ =
-          Logger.warn(
-            "received an invalid data from consul",
-            metadata: [entry: health]
-          )
+        Logger.warn("received an invalid data from consul health=#{inspect(health)}")
 
         :error
     end

--- a/lib/liblink/cluster/protocol/dealer.ex
+++ b/lib/liblink/cluster/protocol/dealer.ex
@@ -14,6 +14,7 @@
 
 defmodule Liblink.Cluster.Protocol.Dealer do
   use GenServer
+  use Liblink.Logger
 
   alias Liblink.Socket
   alias Liblink.Socket.Device
@@ -22,8 +23,6 @@ defmodule Liblink.Cluster.Protocol.Dealer do
   alias Liblink.Data.Keyword
 
   import Liblink.Guards
-
-  require Logger
 
   @type t :: pid
 
@@ -116,7 +115,7 @@ defmodule Liblink.Cluster.Protocol.Dealer do
         Impl.devices(state)
 
       message ->
-        _ = Logger.debug("discarding unknown call message", metadata: [data: [message: message]])
+        Logger.debug("discarding unknown call message. message=#{inspect(message)}")
         {:noreply, state}
     end
   end
@@ -128,7 +127,7 @@ defmodule Liblink.Cluster.Protocol.Dealer do
         Impl.halt(state)
 
       _message ->
-        _ = Logger.debug("discarding unknown cast message", metadata: [data: [message: message]])
+        Logger.debug("discarding unknown cast message. message=#{inspect(message)}")
         {:noreply, state}
     end
   end

--- a/lib/liblink/cluster/protocol/dealer/impl.ex
+++ b/lib/liblink/cluster/protocol/dealer/impl.ex
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 defmodule Liblink.Cluster.Protocol.Dealer.Impl do
+  use Liblink.Logger
+
   alias Liblink.Timeout
   alias Liblink.Socket
   alias Liblink.Socket.Device
@@ -20,8 +22,6 @@ defmodule Liblink.Cluster.Protocol.Dealer.Impl do
   alias Liblink.Data.Balance
 
   import Liblink.Guards
-
-  require Logger
 
   @type state_t :: %{
           devices: MapSet.t(Device.t()),
@@ -162,7 +162,7 @@ defmodule Liblink.Cluster.Protocol.Dealer.Impl do
         {:noreply, %{state | requests: requests, timeouts: timeouts}}
 
       {nil, _requests} ->
-        _ = Logger.debug("ignoring expired reply")
+        Logger.warn("ignoring expired reply message=#{inspect(message)}")
         {:noreply, state}
     end
   end

--- a/lib/liblink/data/cluster/service.ex
+++ b/lib/liblink/data/cluster/service.ex
@@ -53,4 +53,15 @@ defmodule Liblink.Data.Cluster.Service do
         error
     end
   end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(service, opts) do
+      concat([
+        "#Service",
+        to_doc([id: service.id, protocol: service.protocol], opts)
+      ])
+    end
+  end
 end

--- a/lib/liblink/data/message.ex
+++ b/lib/liblink/data/message.ex
@@ -76,4 +76,15 @@ defmodule Liblink.Data.Message do
         {String.downcase(Atom.to_string(k)), v}
     end)
   end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(message, opts) do
+      concat([
+        "#Message",
+        to_doc([payload: message.payload, metadata: message.metadata], opts)
+      ])
+    end
+  end
 end

--- a/lib/liblink/socket/monitor.ex
+++ b/lib/liblink/socket/monitor.ex
@@ -14,12 +14,11 @@
 
 defmodule Liblink.Socket.Monitor do
   use GenServer
+  use Liblink.Logger
 
   alias Liblink.Nif
   alias Liblink.Socket.Device
   alias Liblink.Socket.Monitor.Impl
-
-  require Logger
 
   @spec start_link([], [{:name, atom}]) :: GenServer.on_start()
   def start_link([], opts \\ [name: __MODULE__]) do
@@ -40,12 +39,12 @@ defmodule Liblink.Socket.Monitor do
 
   @impl true
   def terminate(reason, state) do
-    _ = Logger.debug("socket.monitor is terminated", metadata: [data: [reason: reason]])
+    Logger.debug("socket.monitor is terminated. reason=#{reason}")
 
     if Enum.empty?(state.procs) do
       :ok
     else
-      _ = Logger.info("closing all remaining sockets")
+      Logger.info("closing all remaining sockets")
       _ = Impl.stop(state)
       :ok
     end
@@ -66,7 +65,7 @@ defmodule Liblink.Socket.Monitor do
         Impl.stats(state)
 
       message ->
-        _ = Logger.warn("unexpected message", metadata: [data: [message: message]])
+        Logger.warn("unexpected message. message=#{inspect(message)}")
         {:reply, {:error, :badmsg}, state}
     end
   end
@@ -78,13 +77,13 @@ defmodule Liblink.Socket.Monitor do
         Impl.down(state, tag)
 
       {:EXIT, _from, reason} ->
-        _ = Logger.debug("socket.monitor is exiting", metadata: [data: [reason: reason]])
+        Logger.debug("socket.monitor is exiting. reason=#{reason}")
 
         state = Impl.stop(state)
         {:stop, reason, state}
 
       message ->
-        _ = Logger.warn("unexpected message", metadata: [data: [message: message]])
+        Logger.warn("unexpected message. message=#{inspect(message)}")
         {:noreply, state}
     end
   end

--- a/lib/liblink/socket/monitor/impl.ex
+++ b/lib/liblink/socket/monitor/impl.ex
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 defmodule Liblink.Socket.Monitor.Impl do
+  use Liblink.Logger
+
   alias Liblink.Nif
   alias Liblink.Socket.Device
   alias Liblink.Socket.Sendmsg
   alias Liblink.Socket.Recvmsg
-
-  require Logger
 
   @type state_t :: %{procs: map, socks: map}
 

--- a/lib/liblink/socket/recvmsg.ex
+++ b/lib/liblink/socket/recvmsg.ex
@@ -14,11 +14,10 @@
 
 defmodule Liblink.Socket.Recvmsg do
   use GenServer
+  use Liblink.Logger
 
   alias Liblink.Socket.Shared
   alias Liblink.Socket.Recvmsg.Impl
-
-  require Logger
 
   @opaque state_t :: map
 
@@ -90,11 +89,7 @@ defmodule Liblink.Socket.Recvmsg do
         Impl.consume(consumer, :sync, state)
 
       message ->
-        _ =
-          Logger.warn(
-            "[socket.recvmsg] ignoring unexpected message",
-            metadata: [data: [message: message]]
-          )
+        Logger.warn("ignoring unexpected message. message=#{inspect(message)}")
 
         {:noreply, state}
     end
@@ -113,11 +108,7 @@ defmodule Liblink.Socket.Recvmsg do
         Impl.halt_consumer(:async, state)
 
       message ->
-        _ =
-          Logger.warn(
-            "[socket.recvmsg] ignoring unexpected message",
-            metadata: [data: [message: message]]
-          )
+        Logger.warn("ignoring unexpected message. message=#{inspect(message)}")
 
         {:noreply, state}
     end
@@ -136,11 +127,7 @@ defmodule Liblink.Socket.Recvmsg do
         Impl.on_monitor_message(message, :async, state)
 
       message ->
-        _ =
-          Logger.warn(
-            "[socket.recvmsg] ignoring unexpected message",
-            metadata: [data: [message: message]]
-          )
+        Logger.warn("ignoring unexpected message. message=#{inspect(message)}")
 
         {:noreply, state}
     end

--- a/lib/liblink/socket/recvmsg/fsm.ex
+++ b/lib/liblink/socket/recvmsg/fsm.ex
@@ -28,7 +28,7 @@ defmodule Liblink.Socket.Recvmsg.Fsm do
 
   defmacro __using__([]) do
     quote do
-      require Logger
+      use Liblink.Logger
 
       @behaviour Liblink.Socket.Recvmsg.Fsm
 
@@ -74,11 +74,7 @@ defmodule Liblink.Socket.Recvmsg.Fsm do
 
       @impl true
       def on_monitor_message(message, data) do
-        _ =
-          Logger.warn(
-            "ignoring monitor message",
-            metadata: [data: [message: message, state: __MODULE__]]
-          )
+        Logger.warn("ignoring monitor message message=#{inspect(message)}")
 
         {:cont, :ok, {__MODULE__, data}}
       end

--- a/lib/liblink/socket/recvmsg/impl.ex
+++ b/lib/liblink/socket/recvmsg/impl.ex
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 defmodule Liblink.Socket.Recvmsg.Impl do
+  use Liblink.Logger
+
   alias Liblink.Socket.Device
   alias Liblink.Socket.Recvmsg.Fsm
-
-  require Logger
 
   @moduledoc false
 

--- a/lib/liblink/socket/recvmsg/subs_state.ex
+++ b/lib/liblink/socket/recvmsg/subs_state.ex
@@ -31,20 +31,14 @@ defmodule Liblink.Socket.Recvmsg.SubsState do
         {:cont, :ok, {__MODULE__, data}}
 
       {:error, e} ->
-        _ =
-          Logger.warn(
-            "removing misbehaving consumer [reason: exception]",
-            metadata: [data: [consumer: data.consumer], except: e]
-          )
+        Logger.warn(
+          "removing misbehaving consumer message=#{inspect(message)} reason=#{inspect(e)}"
+        )
 
         Transition.consume_to_recv(message, data)
 
       badmsg ->
-        _ =
-          Logger.warn(
-            "removing misbehaving consumer [reason: badmsg]",
-            metadata: [data: [consumer: data.consumer, badmsg: badmsg]]
-          )
+        Logger.warn("removing misbehaving consumer message=#{inspect(badmsg)} reason=:badmsg")
 
         Transition.consume_to_recv(message, data)
     end
@@ -57,15 +51,11 @@ defmodule Liblink.Socket.Recvmsg.SubsState do
 
     case message do
       {:DOWN, ^tag, :process, _object, _reason} ->
-        _ = Logger.warn("removing dead consumer", data: [tag: tag])
+        Logger.warn("removing dead consumer")
         Transition.consume_to_recv(data)
 
       _otherwise ->
-        _ =
-          Logger.debug(
-            "discarding unknown monitor message",
-            metadata: [data: [message: message, state: __MODULE__]]
-          )
+        Logger.debug("discarding unknown monitor message message=#{inspect(message)}")
 
         {:cont, :ok, {__MODULE__, data}}
     end
@@ -77,11 +67,11 @@ defmodule Liblink.Socket.Recvmsg.SubsState do
       apply(module, function, args)
     rescue
       e ->
-        _ =
-          Logger.warn(
-            "error invoking function",
-            metadata: [data: [function: {module, function, args}], except: e]
-          )
+        Logger.warn(
+          "error invoking function module=#{module} function=#{function} args=#{inspect(args)} except=#{
+            inspect(e)
+          }"
+        )
 
         {:error, e}
     end
@@ -93,11 +83,7 @@ defmodule Liblink.Socket.Recvmsg.SubsState do
       apply(fun, [message])
     rescue
       e ->
-        _ =
-          Logger.warn(
-            "error invoking function",
-            metadata: [data: [function: fun], except: e]
-          )
+        Logger.warn("error invoking function except=#{inspect(e)}")
 
         {:error, e}
     end

--- a/lib/liblink/socket/recvmsg/transition.ex
+++ b/lib/liblink/socket/recvmsg/transition.ex
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 defmodule Liblink.Socket.Recvmsg.Transition do
+  use Liblink.Logger
+
   alias Liblink.Nif
   alias Liblink.Socket.Device
   alias Liblink.Socket.Recvmsg.RecvState
   alias Liblink.Socket.Recvmsg.SubsState
-
-  require Logger
 
   @type consumer_t :: {atom, atom, list} | {atom, atom} | atom | pid | (iodata -> term)
 
@@ -42,8 +42,6 @@ defmodule Liblink.Socket.Recvmsg.Transition do
           {:cont, {:erro, :bad_consumer}, {RecvState, map}}
           | {:cont, :ok, {SendState, map}}
   def recv_to_consume(consumer, data) do
-    _ = Logger.info("recvmsg-fsm: recv -> consume")
-
     consumer =
       case consumer do
         {name, node} when is_atom(name) and is_atom(node) ->
@@ -83,8 +81,6 @@ defmodule Liblink.Socket.Recvmsg.Transition do
 
   @spec consume_to_recv(iodata, map) :: {:cont, :ok, {RecvState, map}}
   def consume_to_recv(message, data) do
-    _ = Logger.info("recvmsg-fsm: consume -> recv")
-
     mqueue = :queue.in(message, data.mqueue)
 
     n_data =
@@ -97,8 +93,6 @@ defmodule Liblink.Socket.Recvmsg.Transition do
 
   @spec consume_to_recv(map) :: {:cont, :ok, {RecvState, map}}
   def consume_to_recv(data) do
-    _ = Logger.info("recvmsg-fsm: consume -> recv")
-
     n_data = Map.delete(data, :consumer)
 
     {:cont, :ok, {RecvState, n_data}}

--- a/lib/liblink/socket/sendmsg.ex
+++ b/lib/liblink/socket/sendmsg.ex
@@ -14,12 +14,11 @@
 
 defmodule Liblink.Socket.Sendmsg do
   use GenServer
+  use Liblink.Logger
 
   alias Liblink.Timeout
   alias Liblink.Socket.Shared
   alias Liblink.Socket.Sendmsg.Impl
-
-  require Logger
 
   import Liblink.Guards
 
@@ -102,11 +101,7 @@ defmodule Liblink.Socket.Sendmsg do
         Impl.sendmsg(message, deadline, :sync, state)
 
       message ->
-        _ =
-          Logger.warn(
-            "[socket.sendmsg] ignoring unexpected message",
-            metadata: [data: [message: message]]
-          )
+        Logger.warn("ignoring unexpected message. message=#{inspect(message)}")
 
         {:noreply, state}
     end
@@ -122,11 +117,7 @@ defmodule Liblink.Socket.Sendmsg do
         Impl.sendmsg(message, deadline, :async, state)
 
       message ->
-        _ =
-          Logger.warn(
-            "[socket.sendmsg] ignoring unexpected message",
-            metadata: [data: [message: message]]
-          )
+        Logger.warn("ignoring unexpected message. message=#{inspect(message)}")
 
         {:noreply, state}
     end
@@ -134,11 +125,7 @@ defmodule Liblink.Socket.Sendmsg do
 
   @impl true
   def handle_info(message, state) do
-    _ =
-      Logger.warn(
-        "[socket.sendmsg] ignoring unexpected message",
-        metadata: [data: [message: message]]
-      )
+    Logger.warn("ignoring unexpected message. message=#{inspect(message)}")
 
     {:noreply, state}
   end

--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -1,0 +1,87 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.Logger do
+  require Logger
+
+  defmacro __using__(_arg) do
+    quote do
+      import Liblink.Logger
+      require Logger
+    end
+  end
+
+  @spec log(
+          %{src: String.t(), fun: String.t()},
+          :debug | :info | :warn | :error,
+          String.t()
+        ) :: nil
+  def log(env, level, message) when is_atom(level) and is_binary(message) do
+    backend = Application.get_env(:liblink, :logger, &Logger.log/2)
+
+    if backend do
+      apply(backend, [
+        level,
+        fn ->
+          Enum.join(["[liblink][#{env.fun}] #{env.src}", message], "\n")
+        end
+      ])
+    end
+
+    nil
+  end
+
+  defmacro debug(message) when is_binary(message) do
+    env = Macro.escape(getenv(__CALLER__))
+
+    quote do
+      Liblink.Logger.log(unquote(env), :debug, unquote(message))
+    end
+  end
+
+  defmacro info(message) when is_binary(message) do
+    env = Macro.escape(getenv(__CALLER__))
+
+    quote do
+      Liblink.Logger.log(unquote(env), :info, message)
+    end
+  end
+
+  defmacro warn(message) when is_binary(message) do
+    env = Macro.escape(getenv(__CALLER__))
+
+    quote do
+      Liblink.Logger.log(unquote(env), :warn, message)
+    end
+  end
+
+  defmacro error(message) when is_binary(message) do
+    env = Macro.escape(getenv(__CALLER__))
+
+    quote do
+      Liblink.Logger.log(unquote(env), :error, message)
+    end
+  end
+
+  defp getenv(env) do
+    %{
+      src: Enum.join([env.file, env.line], ":"),
+      fun:
+        case env.function do
+          {fun, ari} -> Enum.join([env.module, Enum.join([fun, ari], "/")], ".")
+          nil -> Atom.to_string(env.module)
+        end
+    }
+  end
+end

--- a/test/liblink/client_test.exs
+++ b/test/liblink/client_test.exs
@@ -108,7 +108,6 @@ defmodule Liblink.ClientTest do
 
     assert :failure == Message.meta_get(reply, "ll-status")
 
-    assert {:error, {:except, %RuntimeError{message: "except message"}, _stacktrace}} =
-             reply.payload
+    assert {:error, {:except, %RuntimeError{message: "except message"}}} = reply.payload
   end
 end


### PR DESCRIPTION
the purpose of this change is to allow suppressing logging messages or
changing the library log level. we've have to build this mechanism in
the library as elixir has no mechanism that allow configuring this per
application.

the default implementation uses `Logger.log/2` as the backend but you
can use any 2-arity function that takes the log level and the
message (as a function).

it is also possible to disable the logging completely by using:
`Application.set_env(:liblink, :logger, nil)`

incidentally we also change the format of the response when an
exception occurs. the stacktrace is no longer send to the peer, only
the exception.