### PR TITLE
multiple consul datacenter

### DIFF
--- a/lib/liblink/cluster/announce/request_response.ex
+++ b/lib/liblink/cluster/announce/request_response.ex
@@ -40,7 +40,7 @@ defmodule Liblink.Cluster.Announce.RequestResponse do
   def_bang(:new, 2)
 
   @spec new(Consul.t(), Cluster.t()) :: {:ok, t} | :error
-  def new(consul = %Tesla.Client{}, cluster = %Cluster{announce: %Announce{}}) do
+  def new(consul = %Consul{}, cluster = %Cluster{announce: %Announce{}}) do
     net_host = Cfg.protocol_host(:request_response)
     net_port = Cfg.protocol_port(:request_response)
     endpoint = Endpoint.tcp_endpoint(net_host, net_port)

--- a/lib/liblink/cluster/discover/service.ex
+++ b/lib/liblink/cluster/discover/service.ex
@@ -27,7 +27,7 @@ defmodule Liblink.Cluster.Discover.Service do
   @type t :: map
 
   @spec new(Database.t(), Consul.t(), Cluster.t(), Service.protocol()) :: {:ok, t}
-  def new(pid, consul = %Tesla.Client{}, cluster = %Cluster{discover: %Discover{}}, protocol) do
+  def new(pid, consul = %Consul{}, cluster = %Cluster{discover: %Discover{}}, protocol) do
     {:ok, %{database: pid, consul: consul, cluster: cluster, protocol: protocol}}
   end
 

--- a/lib/liblink/data/consul/config.ex
+++ b/lib/liblink/data/consul/config.ex
@@ -22,8 +22,9 @@ defmodule Liblink.Data.Consul.Config do
           {:endpoint, String.t()}
           | {:token, String.t() | nil}
           | {:timeout, non_neg_integer()}
+          | {:datacenters, [String.t()]}
 
-  defstruct [:endpoint, :token, :timeout]
+  defstruct [:endpoint, :token, :timeout, :datacenters]
 
   @spec new!() :: t
   def_bang(:new, 0)
@@ -41,8 +42,10 @@ defmodule Liblink.Data.Consul.Config do
     with {:ok, endpoint} <-
            Keyword.maybe_fetch_binary(options, :endpoint, "http://localhost:8500"),
          {:ok, token} <- Keyword.maybe_fetch_binary(options, :token, nil),
+         {:ok, datacenters} <- Keyword.fetch_list(options, :datacenters, []),
          {:ok, timeout} <- Keyword.fetch_integer(options, :timeout, 1_000) do
-      {:ok, %__MODULE__{endpoint: endpoint, token: token, timeout: timeout}}
+      {:ok,
+       %__MODULE__{endpoint: endpoint, token: token, timeout: timeout, datacenters: datacenters}}
     end
   end
 end

--- a/lib/liblink/network/consul.ex
+++ b/lib/liblink/network/consul.ex
@@ -15,15 +15,20 @@
 defmodule Liblink.Network.Consul do
   alias Liblink.Data.Consul.Config
 
-  @type t :: Tesla.Client.t()
+  defstruct [:agent, :config]
+
+  @type t :: %__MODULE__{}
 
   @spec client(Config.t()) :: t
   def client(config = %Config{}) do
-    Tesla.build_client([
-      {Tesla.Middleware.BaseUrl, config.endpoint},
-      {Tesla.Middleware.Timeout, timeout: config.timeout},
-      {Tesla.Middleware.Headers, [{"x-consul-token", config.token}]},
-      {Tesla.Middleware.JSON, []}
-    ])
+    client =
+      Tesla.build_client([
+        {Tesla.Middleware.BaseUrl, config.endpoint},
+        {Tesla.Middleware.Timeout, timeout: config.timeout},
+        {Tesla.Middleware.Headers, [{"x-consul-token", config.token}]},
+        {Tesla.Middleware.JSON, []}
+      ])
+
+    %__MODULE__{agent: client, config: config}
   end
 end

--- a/lib/liblink/network/consul/agent.ex
+++ b/lib/liblink/network/consul/agent.ex
@@ -19,23 +19,23 @@ defmodule Liblink.Network.Consul.Agent do
   @type check_option :: {:note, String.t()}
 
   @spec service_register(Consul.t(), Service.t()) :: Tesla.Env.result()
-  def service_register(client = %Tesla.Client{}, service = %Service{}) do
+  def service_register(client = %Consul{}, service = %Service{}) do
     payload = Jason.encode!(Service.to_consul(service))
-    Tesla.put(client, "/v1/agent/service/register", payload)
+    Tesla.put(client.agent, "/v1/agent/service/register", payload)
   end
 
-  @spec service_deregister(Tesla.Client.t(), String.t()) :: Tesla.Env.result()
-  def service_deregister(client = %Tesla.Client{}, service_id) when is_binary(service_id) do
-    Tesla.put(client, "/v1/agent/service/deregister/#{service_id}", "")
+  @spec service_deregister(Consul.t(), String.t()) :: Tesla.Env.result()
+  def service_deregister(client = %Consul{}, service_id) when is_binary(service_id) do
+    Tesla.put(client.agent, "/v1/agent/service/deregister/#{service_id}", "")
   end
 
-  @spec services(Tesla.Client.t()) :: Tesla.Env.result()
-  def services(client = %Tesla.Client{}) do
-    Tesla.get(client, "/v1/agent/services")
+  @spec services(Consul.t()) :: Tesla.Env.result()
+  def services(client) do
+    Tesla.get(client.agent, "/v1/agent/services")
   end
 
-  @spec service(Tesla.Client.t(), String.t()) :: Tesla.Env.result()
-  def service(client = %Tesla.Client{}, service_id) when is_binary(service_id) do
+  @spec service(Consul.t(), String.t()) :: Tesla.Env.result()
+  def service(client = %Consul{}, service_id) when is_binary(service_id) do
     with {:ok, reply = %{status: 200}} <- services(client) do
       {:ok,
        Map.update(reply, :body, nil, fn body ->
@@ -46,34 +46,34 @@ defmodule Liblink.Network.Consul.Agent do
     end
   end
 
-  @spec check_pass(Tesla.Client.t(), String.t()) :: Tesla.Env.result()
-  @spec check_pass(Tesla.Client.t(), String.t(), [check_option]) :: Tesla.Env.result()
-  def check_pass(client = %Tesla.Client{}, check_id, params \\ []) when is_binary(check_id) do
+  @spec check_pass(Consul.t(), String.t()) :: Tesla.Env.result()
+  @spec check_pass(Consul.t(), String.t(), [check_option]) :: Tesla.Env.result()
+  def check_pass(client = %Consul{}, check_id, params \\ []) when is_binary(check_id) do
     payload = Jason.encode!(Map.new(params))
-    Tesla.put(client, "/v1/agent/check/pass/#{check_id}", payload)
+    Tesla.put(client.agent, "/v1/agent/check/pass/#{check_id}", payload)
   end
 
-  @spec check_warn(Tesla.Client.t(), String.t()) :: Tesla.Env.result()
-  @spec check_warn(Tesla.Client.t(), String.t(), [check_option]) :: Tesla.Env.result()
-  def check_warn(client = %Tesla.Client{}, check_id, params \\ []) when is_binary(check_id) do
+  @spec check_warn(Consul.t(), String.t()) :: Tesla.Env.result()
+  @spec check_warn(Consul.t(), String.t(), [check_option]) :: Tesla.Env.result()
+  def check_warn(client = %Consul{}, check_id, params \\ []) when is_binary(check_id) do
     payload = Jason.encode!(Map.new(params))
-    Tesla.put(client, "/v1/agent/check/warn/#{check_id}", payload)
+    Tesla.put(client.agent, "/v1/agent/check/warn/#{check_id}", payload)
   end
 
-  @spec check_fail(Tesla.Client.t(), String.t()) :: Tesla.Env.result()
-  @spec check_fail(Tesla.Client.t(), String.t(), [check_option]) :: Tesla.Env.result()
-  def check_fail(client = %Tesla.Client{}, check_id, params \\ []) when is_binary(check_id) do
+  @spec check_fail(Consul.t(), String.t()) :: Tesla.Env.result()
+  @spec check_fail(Consul.t(), String.t(), [check_option]) :: Tesla.Env.result()
+  def check_fail(client = %Consul{}, check_id, params \\ []) when is_binary(check_id) do
     payload = Jason.encode!(Map.new(params))
-    Tesla.put(client, "/v1/agent/check/fail/#{check_id}", payload)
+    Tesla.put(client.agent, "/v1/agent/check/fail/#{check_id}", payload)
   end
 
-  @spec checks(Tesla.Client.t()) :: Tesla.Env.result()
-  def checks(client = %Tesla.Client{}) do
-    Tesla.get(client, "/v1/agent/checks")
+  @spec checks(Consul.t()) :: Tesla.Env.result()
+  def checks(client = %Consul{}) do
+    Tesla.get(client.agent, "/v1/agent/checks")
   end
 
-  @spec check(Tesla.Client.t(), String.t()) :: Tesla.Env.result()
-  def check(client = %Tesla.Client{}, check_id) do
+  @spec check(Consul.t(), String.t()) :: Tesla.Env.result()
+  def check(client = %Consul{}, check_id) do
     with {:ok, reply = %{status: 200}} <- checks(client) do
       {:ok,
        Map.update(reply, :body, nil, fn body ->

--- a/lib/liblink/network/consul/health.ex
+++ b/lib/liblink/network/consul/health.ex
@@ -23,7 +23,7 @@ defmodule Liblink.Network.Consul.Health do
           | {:state, String.t()}
 
   @spec service(Consul.t(), String.t(), [option]) :: Tesla.Env.result()
-  def service(client = %Tesla.Client{}, service, params \\ []) do
+  def service(client = %Consul{}, service, params \\ []) do
     params =
       Enum.map(params, fn {key, value} ->
         if key == :node_meta do
@@ -33,6 +33,6 @@ defmodule Liblink.Network.Consul.Health do
         end
       end)
 
-    Tesla.get(client, "/v1/health/service/#{service}", query: params)
+    Tesla.get(client.agent, "/v1/health/service/#{service}", query: params)
   end
 end


### PR DESCRIPTION
add support for consul with multiple datacenter. the default uses the current datacenter only but an option can be given to search for services in multiple datacenters:

```elixir
config :liblink, :consul, datacenters: ["dc1", "dc2", ...]
```