### PR TITLE
new service spec

### DIFF
--- a/lib/liblink/cluster/discover/service.ex
+++ b/lib/liblink/cluster/discover/service.ex
@@ -56,7 +56,7 @@ defmodule Liblink.Cluster.Discover.Service do
           {:ok, %{status: 200, body: services}} when is_list(services) ->
             {:cont, {:ok, services ++ acc_services}}
 
-          error ->
+          _error ->
             {:halt, :error}
         end
       end)

--- a/test/lib/test/liblink/test_service.ex
+++ b/test/lib/test/liblink/test_service.ex
@@ -5,7 +5,7 @@ defmodule Test.Liblink.TestService do
     echo
   end
 
-  def echo(request) do
+  def echo(request = %Message{}) do
     {:ok, request}
   end
 

--- a/test/liblink/cluster/protocol/dealer_test.exs
+++ b/test/liblink/cluster/protocol/dealer_test.exs
@@ -151,14 +151,11 @@ defmodule Liblink.Cluster.Protocol.Dealer.DealerTest do
 
     test "requests a service", %{dealer: dealer, ping_service: headers} do
       assert {:ok, message} = Dealer.request(dealer, Message.new(:ping, headers))
-      assert {:ok, :success} == Message.meta_fetch(message, "ll-status")
       assert :pong == message.payload
     end
 
     test "request a missing service", %{dealer: dealer} do
-      assert {:ok, message} = Dealer.request(dealer, Message.new(nil))
-      assert {:ok, :failure} == Message.meta_fetch(message, "ll-status")
-      assert {:error, :not_found} == message.payload
+      assert {:error, :not_found, %Message{}} = Dealer.request(dealer, Message.new(nil))
     end
 
     test "can user dealer concurrently", %{dealer: dealer, echo_service: headers} do
@@ -174,7 +171,6 @@ defmodule Liblink.Cluster.Protocol.Dealer.DealerTest do
 
       for {id, reply} <- replies do
         assert {:ok, reply = %Message{}} = reply
-        assert {:ok, :success} = Message.meta_fetch(reply, "ll-status")
         assert id == reply.payload
       end
     end

--- a/test/liblink/data/message_test.exs
+++ b/test/liblink/data/message_test.exs
@@ -22,7 +22,19 @@ defmodule Liblink.Data.MessageTest do
     check all payload <- term(),
               metadata <- map_of(binary(), term()) do
       message = Message.new(payload, metadata)
+      assert {:ok, message} == Message.decode(Message.encode({:ok, message}))
       assert {:ok, message} == Message.decode(Message.encode(message))
+    end
+  end
+
+  property "encode . decode = id | error" do
+    check all payload <- term(),
+              error <- atom(:alphanumeric),
+              metadata <- map_of(binary(), term()) do
+      message = Message.new(payload, metadata)
+
+      assert {:ok, {:error, error, message}} ==
+               Message.decode(Message.encode({:error, error, message}))
     end
   end
 


### PR DESCRIPTION
remove the use of `ll-status` header and encodes the status of the message in a triple. the new spec is:

  * `{:ok, Message.t}` for success;

  * `{:error, atom} | {:error, atom, Message.t}` for failures;

The client will always receive a 3-tuple. `{:error, atom, Message.t}` unless it is a local error [e.g. a local timeout] in which case a 2-tuple is used.