### PR TITLE
middlewares

### DIFF
--- a/lib/liblink/data/message.ex
+++ b/lib/liblink/data/message.ex
@@ -35,6 +35,10 @@ defmodule Liblink.Data.Message do
     Codec.encode({@v0, message.metadata, message.payload})
   end
 
+  def encode({:error, error}) when is_atom(error) do
+    Codec.encode({@v0, :error, error, %{}, nil})
+  end
+
   def encode({:error, error, message = %__MODULE__{}}) when is_atom(error) do
     Codec.encode({@v0, :error, error, message.metadata, message.payload})
   end

--- a/lib/liblink/middleware.ex
+++ b/lib/liblink/middleware.ex
@@ -1,0 +1,118 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.Middleware do
+  alias Liblink.Data.Message
+
+  @type continue :: (Message.t() -> {:ok, Message.t()} | {:error, atom} | {:error, atom, term})
+
+  @callback call(Message.t(), term, continue) ::
+              {:ok, Message.t()} | {:error, atom} | {:error, atom, term}
+
+  defmacro __using__(_args) do
+    quote do
+      @behaviour Liblink.Middleware
+      @before_compile Liblink.Middleware
+
+      import Liblink.Middleware, only: [middleware: 1, middleware: 2]
+
+      Module.register_attribute(__MODULE__, :middlewares, accumulate: true, persist: false)
+    end
+  end
+
+  defmacro middleware(module0, options \\ []) do
+    if [] != Keyword.drop(options, [:data, :only, :except]) do
+      keys =
+        options
+        |> Keyword.keys()
+        |> Enum.join(",")
+
+      raise(RuntimeError, message: "unsupported options: #{keys}")
+    end
+
+    data = Keyword.get(options, :data, nil)
+    only = Keyword.get(options, :only, [])
+    except = Keyword.get(options, :except, [])
+
+    quote do
+      module =
+        case unquote(module0) do
+          :logger -> Liblink.Middleware.Logger
+          :except -> Liblink.Middleware.Except
+          module -> module
+        end
+
+      @middlewares {module, unquote(data), MapSet.new(unquote(only)), MapSet.new(unquote(except))}
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def __advise__(function, message) when is_atom(function) do
+        middlewares =
+          Enum.reduce(@middlewares, [], fn {middleware, data, only, except}, middlewares ->
+            use_middleware? =
+              (Enum.empty?(only) or MapSet.member?(only, function)) and
+                not MapSet.member?(except, function)
+
+            if use_middleware? do
+              [{middleware, data} | middlewares]
+            else
+              middlewares
+            end
+          end)
+
+        Liblink.Middleware.advise_function(
+          Enum.reverse(middlewares),
+          {__MODULE__, function},
+          message
+        )
+      end
+    end
+  end
+
+  @spec advise_ext(module, atom, Message.t()) ::
+          {:ok, Message.t()} | {:error, atom} | {:error, atom, Message.t()}
+  def advise_ext(mod, fun, message) do
+    middlewares = [{Liblink.Middleware.Logger, nil}, {Liblink.Middleware.Except, nil}]
+    advise_function(middlewares, {mod, fun}, message)
+  end
+
+  @spec advise_function([{module, term}], {module, atom}, Message.t()) ::
+          {:ok, Message.t()} | {:error, atom} | {:error, atom, Message.t()}
+  def advise_function([], {mod, fun}, message) do
+    if function_exported?(mod, fun, 1) do
+      case apply(mod, fun, [message]) do
+        term = {:ok, %Message{}} ->
+          term
+
+        term = {:error, error} when is_atom(error) ->
+          term
+
+        term = {:error, error, %Message{}} when is_atom(error) ->
+          term
+
+        _term ->
+          {:error, :bad_service}
+      end
+    else
+      {:error, :not_found}
+    end
+  end
+
+  def advise_function([{mod, data} | mod_rest], function, message) do
+    continue = fn message -> advise_function(mod_rest, function, message) end
+    apply(mod, :call, [message, data, continue])
+  end
+end

--- a/lib/liblink/middleware/except.ex
+++ b/lib/liblink/middleware/except.ex
@@ -1,0 +1,36 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.Middleware.Except do
+  use Liblink.Logger
+  use Liblink.Middleware
+
+  alias Liblink.Data.Message
+
+  @impl true
+  def call(request, _data, continue) do
+    try do
+      continue.(request)
+    rescue
+      except ->
+        stacktrace = Exception.format_stacktrace(System.stacktrace())
+
+        Liblink.Logger.warn(fn ->
+          "exception calling service\n" <> stacktrace
+        end)
+
+        {:error, :internal_error, Message.new(except)}
+    end
+  end
+end

--- a/lib/liblink/middleware/logger.ex
+++ b/lib/liblink/middleware/logger.ex
@@ -1,0 +1,72 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.Middleware.Logger do
+  use Liblink.Logger
+  use Liblink.Middleware
+
+  @impl true
+  def call(request, _data, continue) do
+    offset = :erlang.monotonic_time()
+
+    case continue.(request) do
+      reply = {:ok, _term} ->
+        {duration, unit} = normalize(:erlang.monotonic_time() - offset, :native)
+
+        Liblink.Logger.info(fn ->
+          Enum.join(["success", " duration=#{duration}#{unit}", " request=#{inspect(request)}"])
+        end)
+
+        reply
+
+      reply ->
+        {duration, unit} = normalize(:erlang.monotonic_time() - offset, :native)
+
+        Liblink.Logger.warn(fn ->
+          Enum.join([
+            "failure",
+            " duration=#{duration}#{unit}",
+            " request=#{inspect(request)}",
+            " reply=#{inspect(reply)}"
+          ])
+        end)
+
+        reply
+    end
+  end
+
+  defp normalize(duration, :native) do
+    normalize(:erlang.convert_time_unit(duration, :native, :nanosecond), :ns)
+  end
+
+  defp normalize(duration, unit) do
+    if duration > 1000_000 do
+      case unit do
+        :ns ->
+          normalize(div(duration, 1000), :us)
+
+        :us ->
+          normalize(div(duration, 1000), :ms)
+
+        :ms ->
+          normalize(div(duration, 1000), :s)
+
+        :s ->
+          {duration, :s}
+      end
+    else
+      {duration, unit}
+    end
+  end
+end

--- a/test/lib/test/liblink/test_halt_middleware.ex
+++ b/test/lib/test/liblink/test_halt_middleware.ex
@@ -1,0 +1,29 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.TestHaltMiddleware do
+  use Liblink.Middleware
+
+  alias Liblink.Data.Message
+
+  middleware(Liblink.TestHaltMiddleware)
+
+  def call(_message, _data, _continue) do
+    {:error, :halt}
+  end
+
+  def foobar(_message) do
+    {:ok, Message.new(nil)}
+  end
+end

--- a/test/liblink/client_test.exs
+++ b/test/liblink/client_test.exs
@@ -100,7 +100,7 @@ defmodule Liblink.ClientTest do
   end
 
   test "request a service that raises", %{cluster: cluster, service: service} do
-    assert {:error, :except, reply} =
+    assert {:error, :internal_error, reply} =
              Client.request(cluster.id, service.id, :exception, Message.new("except message"))
 
     assert %RuntimeError{message: "except message"} = reply.payload

--- a/test/liblink/cluster/protocol/router_test.exs
+++ b/test/liblink/cluster/protocol/router_test.exs
@@ -50,14 +50,6 @@ defmodule Liblink.Cluster.Protocol.RouterTest do
       {:ok, [router: router]}
     end
 
-    test "response includes date header", %{router: router} do
-      now = DateTime.utc_now()
-      reply = ping_request(router)
-
-      assert {:ok, date} = Message.meta_fetch(reply, "ll-timestamp")
-      assert 1 >= DateTime.diff(now, date, :seconds)
-    end
-
     test "application metadata", %{router: router} do
       reply_with = {:ok, Message.new(nil, %{foobar: :term})}
       reply = echo_request(router, {:echo, reply_with})
@@ -82,7 +74,7 @@ defmodule Liblink.Cluster.Protocol.RouterTest do
     end
 
     test "service misbehaving", %{router: router} do
-      reply_with = :bad_return
+      reply_with = :misbehaving
       assert {:error, :bad_service, %Message{}} = echo_request(router, {:echo, reply_with})
     end
   end
@@ -98,12 +90,6 @@ defmodule Liblink.Cluster.Protocol.RouterTest do
     payload
     |> Message.new()
     |> Message.meta_put_new("ll-service-id", {"liblink", :echo})
-    |> request(router)
-  end
-
-  defp ping_request(router) do
-    Message.new(:ping)
-    |> Message.meta_put_new("ll-service-id", {"liblink", :ping})
     |> request(router)
   end
 end

--- a/test/liblink/middleware/except_test.exs
+++ b/test/liblink/middleware/except_test.exs
@@ -1,0 +1,40 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.Middleware.ExceptTest do
+  use ExUnit.Case, async: true
+
+  alias Liblink.Data.Message
+  alias Liblink.Middleware.Except
+
+  @moduletag capture_log: true
+
+  describe "call" do
+    test "capture exception" do
+      expected = {:error, :internal_error, Message.new(%RuntimeError{message: "foobar"})}
+
+      assert expected ==
+               Except.call(Message.new(nil), :unused, fn _ ->
+                 raise(RuntimeError, message: "foobar")
+               end)
+    end
+
+    test "bypass otherwise" do
+      assert {:ok, nil} ==
+               Except.call(Message.new(nil), :unused, fn _ ->
+                 {:ok, nil}
+               end)
+    end
+  end
+end

--- a/test/liblink/middleware/logger_test.exs
+++ b/test/liblink/middleware/logger_test.exs
@@ -1,0 +1,41 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.Middleware.LoggerTest do
+  use ExUnit.Case, async: true
+
+  alias Liblink.Middleware.Logger
+
+  import ExUnit.CaptureLog
+
+  describe "call" do
+    test "log success when ans = {:ok, _term}" do
+      logline =
+        capture_log(fn ->
+          Logger.call(:foobar, :any, fn _ -> {:ok, :any} end)
+        end)
+
+      assert String.contains?(logline, "success")
+    end
+
+    test "log failure when ans != {:ok, _term}" do
+      logline =
+        capture_log(fn ->
+          Logger.call(:foobar, :any, fn _ -> {:error, :error} end)
+        end)
+
+      assert String.contains?(logline, "failure")
+    end
+  end
+end

--- a/test/liblink/middleware_test.exs
+++ b/test/liblink/middleware_test.exs
@@ -1,0 +1,94 @@
+# Copyright (C) 2018  Xerpa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Liblink.MiddlewareTest do
+  use ExUnit.Case, async: true
+
+  alias Liblink.Middleware
+  alias Liblink.Data.Message
+  alias Liblink.TestHaltMiddleware
+
+  @moduletag capture_log: true
+
+  describe "adive_ext" do
+    test "valid forms" do
+      assert {:ok, Message.new(nil)} ==
+               with_mock(
+                 fn m -> {:ok, m} end,
+                 fn ->
+                   Middleware.advise_ext(__MODULE__, :mock, Message.new(nil))
+                 end
+               )
+
+      assert {:error, :error} ==
+               with_mock(
+                 fn _ -> {:error, :error} end,
+                 fn ->
+                   Middleware.advise_ext(__MODULE__, :mock, Message.new(nil))
+                 end
+               )
+
+      assert {:error, :error, Message.new(:error)} ==
+               with_mock(
+                 fn _ -> {:error, :error, Message.new(:error)} end,
+                 fn ->
+                   Middleware.advise_ext(__MODULE__, :mock, Message.new(nil))
+                 end
+               )
+    end
+
+    test "on invalid form" do
+      assert {:error, :bad_service} ==
+               with_mock(
+                 fn _ -> {:invalid, :reply} end,
+                 fn ->
+                   Middleware.advise_ext(__MODULE__, :mock, Message.new(nil))
+                 end
+               )
+    end
+
+    test "add except middleware" do
+      assert {:error, :internal_error, Message.new(%RuntimeError{message: "foobar"})} ==
+               with_mock(
+                 fn _ -> raise(RuntimeError, message: "foobar") end,
+                 fn ->
+                   Middleware.advise_ext(__MODULE__, :mock, Message.new(nil))
+                 end
+               )
+    end
+  end
+
+  describe "middleware" do
+    test "define an __advise__ function" do
+      assert {:error, :halt} == TestHaltMiddleware.__advise__(:foobar, Message.new(nil))
+    end
+
+    test "keeps the original function untouched" do
+      assert {:ok, Message.new(nil)} == TestHaltMiddleware.foobar(Message.new(nil))
+    end
+  end
+
+  def mock(message) do
+    handler = Process.get(:handler)
+    handler.(message)
+  end
+
+  def with_mock(handler, expr) when is_function(handler, 1) do
+    Task.async(fn ->
+      Process.put(:handler, handler)
+      expr.()
+    end)
+    |> Task.await(:infinity)
+  end
+end


### PR DESCRIPTION
refactor router logic into middlewares: logger and except.

A middleware must define a `call` function which receives the message and the continuation. the middleware may act on the input as well as the output or even halt the request [useful for future auth middlewares].