### PR TITLE
Improves error message logging.

### DIFF
--- a/lib/liblink/middleware/except.ex
+++ b/lib/liblink/middleware/except.ex
@@ -25,10 +25,10 @@ defmodule Liblink.Middleware.Except do
       continue.(request)
     rescue
       except ->
-        stacktrace = Exception.format_stacktrace(System.stacktrace())
+        message = Exception.format(:error, except, System.stacktrace())
 
         Liblink.Logger.warn(fn ->
-          "exception calling #{module}.#{function}\n" <> stacktrace
+          "exception calling #{module}.#{function}\n\n" <> message
         end)
 
         {:error, :internal_error, Message.new(except)}


### PR DESCRIPTION
Slightly improves error messages. Adds the error message and the error type.

After:

```
[warn] [liblink][Elixir.Liblink.Middleware.Except.call/4] /mnt/svcs/kairos/deps/liblink/lib/liblink/middleware/except.ex:30
exception calling Elixir.Kairos.API.Entry.EntryAPI.upsert_entries
    (kairos) lib/data/entry/positional_file.ex:18: Kairos.Data.Entry.PositionalFile.starts_with_header?/1
    (kairos) lib/data/entry/parser.ex:20: Kairos.Data.Entry.Parser.parse_guessing/1
    (kairos) lib/data/entry/parser.ex:9: Kairos.Data.Entry.Parser.parse/1
    (kairos) lib/api/entry/entry_service.ex:7: Kairos.API.Entry.EntryService.parse/2
    (kairos) lib/api/entry/entry_api.ex:21: anonymous fn/1 in Kairos.API.Entry.EntryAPI.upsert_entries/1
    (ecto) lib/ecto/adapters/sql.ex:576: anonymous fn/3 in Ecto.Adapters.SQL.do_transaction/3
    (db_connection) lib/db_connection.ex:1283: DBConnection.transaction_run/4
    (db_connection) lib/db_connection.ex:1207: DBConnection.run_begin/3
```

Before:

```
[warn] [liblink][Elixir.Liblink.Middleware.Except.call/4] /mnt/svcs/kairos/deps/liblink/lib/liblink/middleware/except.ex:31
exception calling Elixir.Kairos.API.Entry.EntryAPI.upsert_entries

** (MatchError) no match of right hand side value: []
    (kairos) lib/data/entry/positional_file.ex:18: Kairos.Data.Entry.PositionalFile.starts_with_header?/1
    (kairos) lib/data/entry/parser.ex:20: Kairos.Data.Entry.Parser.parse_guessing/1
    (kairos) lib/data/entry/parser.ex:9: Kairos.Data.Entry.Parser.parse/1
    (kairos) lib/api/entry/entry_service.ex:7: Kairos.API.Entry.EntryService.parse/2
    (kairos) lib/api/entry/entry_api.ex:21: anonymous fn/1 in Kairos.API.Entry.EntryAPI.upsert_entries/1
    (ecto) lib/ecto/adapters/sql.ex:576: anonymous fn/3 in Ecto.Adapters.SQL.do_transaction/3
    (db_connection) lib/db_connection.ex:1283: DBConnection.transaction_run/4
    (db_connection) lib/db_connection.ex:1207: DBConnection.run_begin/3
```