### PR TITLE
add recommended Elixir and Erlang/OTP combinations to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: elixir
 dist: bionic
 
-elixir:
-  - 1.6
-otp_release:
-  - 20.3.8
-  - 20.3.8.22
+matrix:
+  include:
+    - otp_release: 19.3.6.13
+      elixir: 1.6.6
+    - otp_release: 19.3.6.13
+      elixir: 1.7.4
+    - otp_release: 20.3.8.26
+      elixir: 1.8.2
+    - otp_release: 21.3
+      elixir: 1.9.4
+    - otp_release: 21.3.8.17
+      elixir: 1.10.4
+    - otp_release: 23.0.3
+      elixir: 1.10.4
 
 sudo: required
 services: docker


### PR DESCRIPTION
Related to https://github.com/Xerpa/liblink/pull/26. This PR keeps Travis CI, the other migrates to GitHub Actions.